### PR TITLE
Missing version parameter on Feeds endpoint

### DIFF
--- a/lib/mws.js
+++ b/lib/mws.js
@@ -28,7 +28,7 @@ var endpoint = {
     },
     'Feeds': {
         'type': '/',
-        'version': ''
+        'version': '2009-01-01'
     },
     'Reports': {
         'type': '/Reports/',


### PR DESCRIPTION
I added the right version to do "Feeds" requests to MWS.
I fixed it since I got this error:

{ Type: 'Sender',
     Code: 'InvalidRequest',
     Message: 'parameter Version failed a validation check: value cannot be empty.',
     Detail: '' },
