### PR TITLE
Check for ISBN in allowed "idType" was missing

### DIFF
--- a/lib/products.js
+++ b/lib/products.js
@@ -182,7 +182,7 @@ module.exports = {
         }
 
         // Control the IdType - allowed only (ASIN,GCID,SellerSKU,UPC,EAN,ISBN,JAN)
-        if (params['IdType'] !== 'ASIN' && params['IdType'] !== 'GCID' && params['IdType'] !== 'SellerSKU' && params['IdType'] !== 'UPC' && params['IdType'] !== 'EAN' && params['IdType'] !== 'JAN') {
+        if (params['IdType'] !== 'ASIN' && params['IdType'] !== 'GCID' && params['IdType'] !== 'SellerSKU' && params['IdType'] !== 'UPC' && params['IdType'] !== 'EAN' && params['IdType'] !== 'JAN' && params['IdType'] !== 'ISBN') {
             cb({
                 'Error': "Usage of unallowed IdType. Allowed are ASIN,GCID,SellerSKU,UPC,EAN,ISBN,JAN"
             }, null);


### PR DESCRIPTION
GetMatchingProductForId

Error message is correct: "Usage of unallowed IdType. Allowed are ASIN,GCID,SellerSKU,UPC,EAN,ISBN,JAN"
But there missing condition check for ISBN in "if" statement.